### PR TITLE
Add support for ApprovalStore in @EnableAuthorizationServer

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/OAuth2AuthorizationServerConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/OAuth2AuthorizationServerConfigurer.java
@@ -133,7 +133,7 @@ public final class OAuth2AuthorizationServerConfigurer extends
 	public UserApprovalHandler getUserApprovalHandler() {
 		return userApprovalHandler;
 	}
-
+	
 	public OAuth2AuthorizationServerConfigurer allowFormAuthenticationForClients() {
 		this.allowFormAuthenticationForClients = true;
 		return this;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/SpelView.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/SpelView.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.security.oauth2.provider.endpoint;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
+import org.springframework.web.servlet.View;
+
+/**
+ * Simple String template renderer.
+ * 
+ */
+class SpelView implements View {
+
+	private final String template;
+
+	private final SpelExpressionParser parser = new SpelExpressionParser();
+
+	private final StandardEvaluationContext context = new StandardEvaluationContext();
+
+	private PropertyPlaceholderHelper helper;
+
+	private PlaceholderResolver resolver;
+
+	public SpelView(String template) {
+		this.template = template;
+		this.context.addPropertyAccessor(new MapAccessor());
+		this.helper = new PropertyPlaceholderHelper("${", "}");
+		this.resolver = new PlaceholderResolver() {
+			public String resolvePlaceholder(String name) {
+				Expression expression = parser.parseExpression(name);
+				Object value = expression.getValue(context);
+				return value == null ? null : value.toString();
+			}
+		};
+	}
+
+	public String getContentType() {
+		return "text/html";
+	}
+
+	public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response)
+			throws Exception {
+		Map<String, Object> map = new HashMap<String, Object>(model);
+		map.put("path", (Object) request.getContextPath());
+		context.setRootObject(map);
+		String result = helper.replacePlaceholders(template, resolver);
+		response.setContentType(getContentType());
+		response.getWriter().append(result);
+	}
+
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelApprovalEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelApprovalEndpoint.java
@@ -1,24 +1,15 @@
 package org.springframework.security.oauth2.provider.endpoint;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.context.expression.MapAccessor;
-import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.util.PropertyPlaceholderHelper;
-import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.View;
 
 /**
- * Controller for displaying the approval and error pages for the authorization server.
+ * Controller for displaying the approval page for the authorization server.
  * 
  * @author Dave Syer
  */
@@ -28,73 +19,56 @@ public class WhitelabelApprovalEndpoint {
 
 	@RequestMapping("/oauth/confirm_access")
 	public ModelAndView getAccessConfirmation(Map<String, Object> model, HttpServletRequest request) throws Exception {
-		if (request.getAttribute("_csrf")!=null) {
+		String template = createTemplate(model, request);
+		if (request.getAttribute("_csrf") != null) {
 			model.put("_csrf", request.getAttribute("_csrf"));
 		}
-		return new ModelAndView(new SpelView(APPROVAL), model);
+		return new ModelAndView(new SpelView(template), model);
 	}
 
-	@RequestMapping("/oauth/error")
-	public ModelAndView handleError(HttpServletRequest request) {
-		Map<String, Object> model = new HashMap<String, Object>();
-		model.put("error", request.getAttribute("error"));
-		return new ModelAndView(new SpelView(ERROR), model);
+	protected String createTemplate(Map<String, Object> model, HttpServletRequest request) {
+		String template = TEMPLATE;
+		if (model.containsKey("scopes") || request.getAttribute("scopes") != null) {
+			template = template.replace("%scopes%", createScopes(model, request)).replace("%denial%", "");
+		}
+		else {
+			template = template.replace("%scopes%", "").replace("%denial%", DENIAL);
+		}
+		if (model.containsKey("_csrf") || request.getAttribute("_csrf") != null) {
+			template = template.replace("%csrf%", CSRF);
+		}
+		else {
+			template = template.replace("%csrf%", "");
+		}
+		return template;
 	}
 
-	/**
-	 * Simple String template renderer.
-	 * 
-	 */
-	private static class SpelView implements View {
-
-		private final String template;
-
-		private final SpelExpressionParser parser = new SpelExpressionParser();
-
-		private final StandardEvaluationContext context = new StandardEvaluationContext();
-
-		private PropertyPlaceholderHelper helper;
-
-		private PlaceholderResolver resolver;
-
-		public SpelView(String template) {
-			this.template = template;
-			this.context.addPropertyAccessor(new MapAccessor());
-			this.helper = new PropertyPlaceholderHelper("${", "}");
-			this.resolver = new PlaceholderResolver() {
-				public String resolvePlaceholder(String name) {
-					Expression expression = parser.parseExpression(name);
-					Object value = expression.getValue(context);
-					return value == null ? null : value.toString();
-				}
-			};
+	private CharSequence createScopes(Map<String, Object> model, HttpServletRequest request) {
+		StringBuilder builder = new StringBuilder("<ul>");
+		@SuppressWarnings("unchecked")
+		Map<String, String> scopes = (Map<String, String>) (model.containsKey("scopes") ? model.get("scopes") : request
+				.getAttribute("scopes"));
+		for (String scope : scopes.keySet()) {
+			String approved = "true".equals(scopes.get(scope)) ? " checked" : "";
+			String denied = !"true".equals(scopes.get(scope)) ? " checked" : "";
+			String value = SCOPE.replace("%scope%", scope).replace("%key%", scope).replace("%approved%", approved)
+					.replace("%denied%", denied);
+			builder.append(value);
 		}
-
-		public String getContentType() {
-			return "text/html";
-		}
-
-		public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response)
-				throws Exception {
-			Map<String, Object> map = new HashMap<String, Object>(model);
-			map.put("path", (Object) request.getContextPath());
-			context.setRootObject(map);
-			String result = helper.replacePlaceholders(template, resolver);
-			response.setContentType(getContentType());
-			response.getWriter().append(result);
-		}
-
+		builder.append("</ul>");
+		return builder.toString();
 	}
 
-	private static String CSRF = "${#root['_csrf']!=null ? '<input type=\"hidden\" name=\"' + _csrf.parameterName + '\""
-			+ " value=\"' + _csrf.token + '\" />' : ''}";
+	private static String CSRF = "<input type='hidden' name='${_csrf.parameterName}' value='${_csrf.token}' />";
 
-	private static String APPROVAL = "<html><body><h1>OAuth Approval</h1>"
+	private static String DENIAL = "<form id='denialForm' name='denialForm' action='${path}/oauth/authorize' method='post'><input name='user_oauth_approval' value='false' type='hidden'/>%csrf%<label><input name='deny' value='Deny' type='submit'/></label></form>";
+
+	private static String TEMPLATE = "<html><body><h1>OAuth Approval</h1>"
 			+ "<p>Do you authorize '${authorizationRequest.clientId}' to access your protected resources?</p>"
-			+ "<form id='confirmationForm' name='confirmationForm' action='${path}/oauth/authorize' method='post'><input name='user_oauth_approval' value='true' type='hidden'/><label><input name='authorize' value='Authorize' type='submit'></label>"+CSRF+"</form>"
-			+ "<form id='denialForm' name='denialForm' action='${path}/oauth/authorize' method='post'><input name='user_oauth_approval' value='false' type='hidden'/><label><input name='deny' value='Deny' type='submit'></label>"+CSRF+"</form>"
-			+ "</body></html>";
+			+ "<form id='confirmationForm' name='confirmationForm' action='${path}/oauth/authorize' method='post'><input name='user_oauth_approval' value='true' type='hidden'/>%csrf%%scopes%<label><input name='authorize' value='Authorize' type='submit'/></label></form>"
+			+ "%denial%</body></html>";
 
-	private static String ERROR = "<html><body><h1>OAuth Error</h1><p>${error.summary}</p></body></html>";
+	private static String SCOPE = "<li><div class='form-group'>%scope%: <input type='radio' name='%key%'"
+			+ " value='true'%approved%>Approve</input> <input type='radio' name='%key%' value='false'%denied%>Deny</input></div></li>";
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
@@ -1,0 +1,28 @@
+package org.springframework.security.oauth2.provider.endpoint;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Controller for displaying the error page for the authorization server.
+ * 
+ * @author Dave Syer
+ */
+@FrameworkEndpoint
+public class WhitelabelErrorEndpoint {
+
+	@RequestMapping("/oauth/error")
+	public ModelAndView handleError(HttpServletRequest request) {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("error", request.getAttribute("error"));
+		return new ModelAndView(new SpelView(ERROR), model);
+	}
+
+	private static String ERROR = "<html><body><h1>OAuth Error</h1><p>${error.summary}</p></body></html>";
+
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpointTests.java
@@ -44,6 +44,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.TokenGranter;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler;
+import org.springframework.security.oauth2.provider.approval.InMemoryApprovalStore;
 import org.springframework.security.oauth2.provider.approval.UserApprovalHandler;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.oauth2.provider.code.AuthorizationCodeServices;
@@ -124,6 +125,15 @@ public class AuthorizationEndpointTests {
 		ModelAndView result = endpoint.authorize(model, getAuthorizationRequest("foo", null, null, "read", Collections.singleton("code"))
 				.getRequestParameters(), sessionStatus, principal);
 		assertEquals("forward:/oauth/confirm_access", result.getViewName());
+	}
+
+	@Test
+	public void testApprovalStoreAddsScopes() throws Exception {
+		endpoint.setApprovalStore(new InMemoryApprovalStore());
+		ModelAndView result = endpoint.authorize(model, getAuthorizationRequest("foo", null, null, "read", Collections.singleton("code"))
+				.getRequestParameters(), sessionStatus, principal);
+		assertEquals("forward:/oauth/confirm_access", result.getViewName());
+		assertTrue(result.getModel().containsKey("scopes"));
 	}
 
 	@Test(expected = OAuth2Exception.class)

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpointTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package org.springframework.security.oauth2.provider.endpoint;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class WhitelabelErrorEndpointTests {
+	
+	private WhitelabelErrorEndpoint endpoint = new WhitelabelErrorEndpoint();
+	private MockHttpServletRequest request = new MockHttpServletRequest();
+	private MockHttpServletResponse response = new MockHttpServletResponse();
+
+	@Test
+	public void testErrorPage() throws Exception {
+		request.setContextPath("/foo");
+		request.setAttribute("error", new InvalidClientException("FOO"));
+		ModelAndView result = endpoint.handleError(request);
+		result.getView().render(result.getModel(), request , response);
+		String content = response.getContentAsString();
+		assertTrue("Wrong content: " + content, content.contains("OAuth Error"));
+		assertTrue("Wrong content: " + content, content.contains("invalid_client"));
+	}
+
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/DefaultAuthorizationRequestFactoryTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/DefaultAuthorizationRequestFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestFactory;
 
@@ -34,7 +35,7 @@ import org.springframework.security.oauth2.provider.request.DefaultOAuth2Request
  * @author Dave Syer
  * 
  */
-public class DefaultAuthorizationRequestManagerTests {
+public class DefaultAuthorizationRequestFactoryTests {
 
 	private BaseClientDetails client = new BaseClientDetails();
 
@@ -58,6 +59,12 @@ public class DefaultAuthorizationRequestManagerTests {
 	@Test
 	public void testCreateAuthorizationRequest() {
 		AuthorizationRequest request = factory.createAuthorizationRequest(Collections.singletonMap("client_id", "foo"));
+		assertEquals("foo", request.getClientId());
+	}
+
+	@Test
+	public void testCreateTokenRequest() {
+		TokenRequest request = factory.createTokenRequest(Collections.singletonMap("client_id", "foo"), client);
 		assertEquals("foo", request.getClientId());
 	}
 


### PR DESCRIPTION
If user defines a @Bean of type ApprovalStore the AuthorizationEndpoint and WhitelabelApprovalEndpoint change their behaviour accordingly.

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://spring.io/security-policy
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
